### PR TITLE
Bugfix: returns String w/o filters

### DIFF
--- a/src/GlobalFilterable.php
+++ b/src/GlobalFilterable.php
@@ -9,11 +9,11 @@ trait GlobalFilterable
     public function globalFiltered($model, $filters = [])
     {
         $request = request();
+
+        $model = $model instanceof Builder ? $model : (new $model)->newQuery();
+        
         if ($request->has('filters')) {
             $request->range = optional($request)->range ?? 3600;
-
-            $model = $model instanceof Builder ? $model : (new $model)->newQuery();
-
             foreach (json_decode($request->filters, true) as $filter => $value) {
                 if(in_array($filter, $filters)){
                   $model = (new $filter)->apply($request, $model, $value);


### PR DESCRIPTION
fix for:
with no filters set the method returns a string (Model::class)